### PR TITLE
absolute paths of currently opened file

### DIFF
--- a/wakatime.js
+++ b/wakatime.js
@@ -301,6 +301,11 @@ define(function(require, exports, module) {
             if (file.indexOf('~') == 0) {
                 file = c9.home + file.substring(1);
             }
+            else{
+                if (file.indexOf(c9.home, 0) != 0){
+                    file = require("path").join(c9.workspaceDir, file);
+                }
+            }
             var time = Date.now();
             if (isWrite || enoughTimePassed(time) || lastFile != file) {
                 if (fileIsIgnored(file))


### PR DESCRIPTION
In regards to [this post](https://groups.google.com/forum/#!searchin/cloud9-sdk/path/cloud9-sdk/J7pw_SKbOs0/1kefKCe_DwAJ),

When editing a file in my current workspace, the path is relative, returning an error when verifying "`os.path.isfile(args.entity)`" in [main.py](https://github.com/wakatime/wakatime/blob/master/wakatime/main.py):L467

e.g. from wakatime.log:

`{"now": "2016/03/04 22:42:36 +0000", "version": "4.1.10", "plugin": "c9/3.1.1670 c9-wakatime/2.0.0", "time": 1457131356.571209, "caller": "/home/ubuntu/.c9/lib/wakatime/wakatime/main.py", "lineno": 496, "isWrite": true, "file": "/.gitignore", "level": "DEBUG", "message": "File does not exist; ignoring this heartbeat."}` 

where "`/.gitignore`" full path is "`/home/ubuntu/workspace/.gitignore`"

Thanks
